### PR TITLE
feat(routing): support specifying TCP port base for routing nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /*.log
+/config.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-target
-kvs.log
-route.log
+/target
+/*.log

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ This project contains several executables:
 
 Each executable can be started by running the built executable from `target`. Alternatively, it's also possible to combine the build and run steps using `cargo run --bin <bin-name>`, where `<bin-name>` is the name of the executable. Since all nodes expect that an routing node is available, it is recommended to start the `routing` executable first.
 
+For `routing` and `kvs` executables, several environment variables can be set to control the behavior:
+
+- `routing`
+  - **`ANNA_PUBLIC_IP`**: The public IP address to listen on so that other nodes can connect TCP to this node. If not set, TCP mode won't be available.
+  - **`ANNA_TCP_PORT_BASE`**: The base of TCP ports to listen on. The real port used will be `ANNA_TCP_PORT_BASE + thread_id`. If not set, the ports will be allocated by system.
+- `kvs`
+  - **`ANNA_PUBLIC_IP`**: Same as for the `routing` executable.
+
 ### Config Files
 
 All executables (with the exception of the logger) expect the path to a config file as argument. An example for this config file can be found in [`example-config.yml`](example-config.yml).

--- a/src/bin/routing.rs
+++ b/src/bin/routing.rs
@@ -36,8 +36,19 @@ fn main() -> eyre::Result<()> {
         .map(|ip| ip.parse())
         .transpose()
         .context("failed to parse ANNA_PUBLIC_IP")?;
+    let tcp_port_base = std::env::var("ANNA_TCP_PORT_BASE")
+        .ok()
+        .map(|port| port.parse())
+        .transpose()
+        .context("failed to parse ANNA_TCP_PORT_BASE")?;
 
-    routing::run(&config, Arc::new(zenoh), zenoh_prefix.to_owned(), public_ip)
+    routing::run(
+        &config,
+        Arc::new(zenoh),
+        zenoh_prefix.to_owned(),
+        public_ip,
+        tcp_port_base,
+    )
 }
 
 fn set_up_logger() -> Result<(), fern::InitError> {

--- a/src/nodes/routing/mod.rs
+++ b/src/nodes/routing/mod.rs
@@ -416,7 +416,7 @@ impl RoutingNode {
                 query = address_request_stream.select_next_some() => {
                     log::info!("handling address request for {}", query.selector());
                     let serialized_reply = self.seed_handler();
-                    query.reply_async(Sample::new(query.key_selector().to_owned() ,serialized_reply)).await;
+                    query.reply_async(Sample::new(query.key_selector().to_owned(), serialized_reply)).await;
                 }
                 sample = notify_stream.select_next_some() => {
                     let parsed = serde_json::from_str(&sample.value.as_string()?)

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -43,7 +43,7 @@ fn get_set() {
         let zenoh = zenoh.clone();
         let zenoh_prefix = zenoh_prefix.clone();
         thread::spawn(move || {
-            routing::run(&config, zenoh, zenoh_prefix, None)
+            routing::run(&config, zenoh, zenoh_prefix, None, None)
                 .context("Routing task failed")
                 .unwrap()
         })


### PR DESCRIPTION
This PR adds support for specifying TCP port base for routing nodes, so that they can listen to fixed ports instead of ports allocated by system. The port value is specified via `ANNA_TCP_PORT_BASE`, like the already existing `ANNA_PUBLIC_IP`.

The feature is used by [WasmEdge Anna client](https://github.com/WasmEdge/wasmedge-db-drivers/tree/main/anna). The latter can only connect to routing and KVS nodes through vanilla TCP, instead of Zenoh, so fixed TCP ports are necessary.