### PR TITLE
Remove `oldtime` feature from chrono to avoid dependency on `time` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
  "winapi",
 ]
 
@@ -2093,17 +2092,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0.126", features = ["derive", "rc"] }
 serde_yaml = "0.8.17"
 argh = "0.1.4"
 eyre = "0.6.5"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 bytes = "1.0.1"
 uuid = { version = "1.0.0", features = ["v4"] }
 smol = "1.2.5"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -8,6 +8,9 @@ license = "Apache-2.0"
 
 [dependencies]
 serde = { version = "1.0.126", features = ["derive", "rc"] }
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "0.4.19", default-features = false, features = [
+    "clock",
+    "serde",
+] }
 eyre = "0.6.5"
 serde_json = "1.0.64"


### PR DESCRIPTION
Version 0.1 of the time crate contains a vulnerability. Apparantly it's not affecting `chrono`, but we don't the features that depend on it, so we disabling is safer.
