### PR TITLE
Update zenoh to `v0.7.0-rc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,13 @@ version = 3
 
 [[package]]
 name = "aes"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -42,9 +41,9 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.8.23",
  "smol",
- "uuid 1.0.0",
+ "uuid",
  "zenoh",
 ]
 
@@ -69,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "argh"
@@ -103,6 +102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f8c380fa28aa1b36107cd97f0196474bb7241bb95a453c5c01a15ac74b2eac"
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,22 +123,22 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
 dependencies = [
- "concurrent-queue",
+ "concurrent-queue 1.2.2",
  "event-listener",
  "futures-core",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
 dependencies = [
+ "async-lock",
  "async-task",
- "concurrent-queue",
+ "concurrent-queue 2.1.0",
  "fastrand",
  "futures-lite",
- "once_cell",
  "slab",
 ]
 
@@ -150,17 +155,16 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.0.4"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c290043c9a95b05d45e952fb6383c67bcb61471f60cfa21e890dba6654234f43"
+checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
 dependencies = [
  "async-channel",
  "async-executor",
  "async-io",
- "async-mutex",
+ "async-lock",
  "blocking",
  "futures-lite",
- "num_cpus",
  "once_cell",
  "tokio",
 ]
@@ -171,7 +175,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
 dependencies = [
- "concurrent-queue",
+ "concurrent-queue 1.2.2",
  "futures-lite",
  "libc",
  "log",
@@ -186,20 +190,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
 dependencies = [
  "event-listener",
-]
-
-[[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
-dependencies = [
- "event-listener",
+ "futures-lite",
 ]
 
 [[package]]
@@ -232,20 +228,20 @@ dependencies = [
 
 [[package]]
 name = "async-rustls"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c86f33abd5a4f3e2d6d9251a9e0c6a7e52eb1113caf893dae8429bf4a53f378"
+checksum = "93b21a03b7c21702a0110f9f8d228763a533570deb376119042dabf33c37a01a"
 dependencies = [
- "futures-lite",
- "rustls 0.19.1",
- "webpki 0.21.4",
+ "futures-io",
+ "rustls",
+ "webpki",
 ]
 
 [[package]]
 name = "async-std"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52580991739c5cdb36cde8b2a516371c0a3b70dda36d916cc08b82372916808c"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
  "async-attributes",
  "async-channel",
@@ -262,7 +258,6 @@ dependencies = [
  "kv-log-macro",
  "log",
  "memchr",
- "num_cpus",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -278,9 +273,9 @@ checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -299,18 +294,9 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "autocfg"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
-dependencies = [
- "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -321,24 +307,21 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64ct"
-version = "1.1.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bitflags"
@@ -352,7 +335,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding 0.1.5",
+ "block-padding",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.4",
@@ -360,11 +343,10 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
- "block-padding 0.2.1",
  "generic-array 0.14.5",
 ]
 
@@ -376,12 +358,6 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
@@ -454,26 +430,36 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
- "generic-array 0.14.5",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_lex",
+ "indexmap",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -486,10 +472,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.6.2"
+name = "concurrent-queue"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
 name = "core-foundation"
@@ -518,33 +513,21 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
- "lazy_static",
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.2.11"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.5",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array 0.14.5",
- "subtle",
+ "typenum",
 ]
 
 [[package]]
@@ -559,12 +542,13 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
- "crypto-bigint",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -584,28 +568,30 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "generic-array 0.14.5",
+ "block-buffer 0.10.3",
+ "const-oid",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
+name = "dirs"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
+name = "dirs-sys"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
@@ -613,23 +599,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.9.0"
+name = "either"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.2"
+name = "errno"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "eyre"
@@ -673,9 +686,9 @@ checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "flume"
-version = "0.10.12"
+version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c03199d0c0ca54bc1ea90ac0d507274c28abcc4f691ae8b4eaa375087c76a"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -685,10 +698,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.21"
+name = "form_urlencoded"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -701,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -711,15 +733,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -728,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-lite"
@@ -749,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -760,15 +782,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-timer"
@@ -778,9 +800,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -792,15 +814,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -877,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -900,6 +913,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,12 +929,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac",
- "digest 0.9.0",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -938,12 +959,21 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -956,12 +986,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnetwork"
-version = "0.18.0"
+name = "io-lifetimes"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4088d739b183546b239688ddbc79891831df421773df95e236daf7867866d355"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "ipnetwork"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f84f1612606f3753f205a4e9a2efd6fe5b4c573a6269b2cc6c3003d44a0d127"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1016,15 +1077,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.124"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libloading"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
@@ -1043,20 +1104,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
  "value-bag",
@@ -1076,24 +1143,11 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
- "autocfg 1.1.0",
-]
-
-[[package]]
-name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
+ "autocfg",
 ]
 
 [[package]]
@@ -1109,15 +1163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,46 +1173,30 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.22.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if",
  "libc",
  "memoffset",
+ "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
-name = "nix"
-version = "0.23.1"
+name = "no-std-net"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
-]
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4547ee5541c18742396ae2c895d0717d0f886d8823b8399cdaf7b07d63ad0480"
+checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
 dependencies = [
- "autocfg 0.1.8",
  "byteorder",
  "lazy_static",
  "libm",
@@ -1185,7 +1214,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-traits",
 ]
 
@@ -1195,7 +1224,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -1206,17 +1235,17 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "libm",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -1233,12 +1262,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,12 +1269,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "ordered-float"
-version = "2.10.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+checksum = "d84eb1409416d254e4a9c8fa56cc24701755025b458f0fcd8e59e1f5f40c23bf"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "output_vt100"
@@ -1270,18 +1299,24 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "paste"
-version = "1.0.7"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.2.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e93a3b1cc0510b03020f33f21e62acdde3dcaef432edc95bea377fbd4c2cd4"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
 dependencies = [
  "base64ct",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
@@ -1328,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -1370,53 +1405,52 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.2.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "116bee8279d783c0cf370efa1a94632f2108e5ef0bb32df31f051647810a4e2c"
+checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
 dependencies = [
  "der",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
-dependencies = [
- "der",
- "pem-rfc7468",
- "pkcs1",
+ "pkcs8",
  "spki",
  "zeroize",
 ]
 
 [[package]]
-name = "pnet"
-version = "0.28.0"
+name = "pkcs8"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6d2a0409666964722368ef5fb74b9f93fac11c18bef3308693c16c6733f103"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "ipnetwork",
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pnet"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caaf5b11fd907ff15cf14a4477bfabca4b37ab9e447a4f8dead969a59cdafad"
+dependencies = [
  "pnet_base",
  "pnet_datalink",
  "pnet_packet",
- "pnet_sys",
  "pnet_transport",
 ]
 
 [[package]]
 name = "pnet_base"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25488cd551a753dcaaa6fffc9f69a7610a412dd8954425bf7ffad5f7d1156fb8"
+checksum = "f9d3a993d49e5fd5d4d854d6999d4addca1f72d86c65adf224a36757161c02b6"
+dependencies = [
+ "no-std-net",
+]
 
 [[package]]
 name = "pnet_datalink"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d1f8ab1ef6c914cf51dc5dfe0be64088ea5f3b08bbf5a31abc70356d271198"
+checksum = "e466faf03a98ad27f6e15cd27a2b7cc89e73e640a43527742977bc503c37f8aa"
 dependencies = [
  "ipnetwork",
  "libc",
@@ -1427,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_macros"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30490e0852e58402b8fae0d39897b08a24f493023a4d6cf56b2e30f31ed57548"
+checksum = "48dd52a5211fac27e7acb14cfc9f30ae16ae0e956b7b779c8214c74559cef4c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1439,18 +1473,18 @@ dependencies = [
 
 [[package]]
 name = "pnet_macros_support"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4714e10f30cab023005adce048f2d30dd4ac4f093662abf2220855655ef8f90"
+checksum = "89de095dc7739349559913aed1ef6a11e73ceade4897dadc77c5e09de6740750"
 dependencies = [
  "pnet_base",
 ]
 
 [[package]]
 name = "pnet_packet"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8588067671d03c9f4254b2e66fecb4d8b93b5d3e703195b84f311cd137e32130"
+checksum = "bc3b5111e697c39c8b9795b9fdccbc301ab696699e88b9ea5a4e4628978f495f"
 dependencies = [
  "glob",
  "pnet_base",
@@ -1460,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_sys"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a3f32b0df45515befd19eed04616f6b56a488da92afc61164ef455e955f07f"
+checksum = "328e231f0add6d247d82421bf3790b4b33b39c8930637f428eef24c4c6a90805"
 dependencies = [
  "libc",
  "winapi",
@@ -1470,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_transport"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "932b2916d693bcc5fa18443dc99142e0a6fd31a6ce75a511868f7174c17e2bce"
+checksum = "ff597185e6f1f5671b3122e4dba892a1c73e17c17e723d7669bd9299cbe7f124"
 dependencies = [
  "libc",
  "pnet_base",
@@ -1519,72 +1553,68 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.8.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d147472bc9a09f13b06c044787b6683cdffa02e2865b7f0fb53d67c49ed2988e"
+checksum = "445cbfe2382fa023c4f2f3c7e1c95c03dcc1df2bf23cebcb2b13e1402c4394d1"
 dependencies = [
  "bytes",
- "futures-channel",
- "futures-util",
- "fxhash",
+ "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustls 0.20.4",
+ "rustc-hash",
+ "rustls",
  "thiserror",
  "tokio",
  "tracing",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359c5eb33845f3ee05c229e65f87cdbc503eea394964b8f1330833d460b4ff3e"
+checksum = "72ef4ced82a24bb281af338b9e8f94429b6eca01b4e66d899f40031f074e74c9"
 dependencies = [
  "bytes",
- "fxhash",
  "rand",
  "ring",
- "rustls 0.20.4",
+ "rustc-hash",
+ "rustls",
  "rustls-native-certs",
- "rustls-pemfile 0.2.1",
  "slab",
  "thiserror",
  "tinyvec",
  "tracing",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
 name = "quinn-udp"
-version = "0.1.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df185e5e5f7611fa6e628ed8f9633df10114b03bbaecab186ec55822c44ac727"
+checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
 dependencies = [
- "futures-util",
  "libc",
- "mio 0.7.14",
  "quinn-proto",
  "socket2",
- "tokio",
  "tracing",
+ "windows-sys",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -1641,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1652,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "ring"
@@ -1672,24 +1702,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.5.0"
+name = "ringbuffer-spsc"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c2603e2823634ab331437001b411b9ed11660fbc4066f3908c84a9439260d"
+checksum = "2fd1938faa63a2362ee1747afb2d10567d0fb1413b9cbd6198a8541485c4f773"
+dependencies = [
+ "array-init",
+ "cache-padded",
+]
+
+[[package]]
+name = "rsa"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "094052d5470cbcef561cb848a7209968c9f12dfa6d668f4bca048ac5de51099c"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
- "lazy_static",
+ "digest 0.10.6",
  "num-bigint-dig",
  "num-integer",
  "num-iter",
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand",
+ "rand_core",
+ "signature",
+ "smallvec",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1701,28 +1748,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.19.1"
+name = "rustix"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
- "base64",
- "log",
- "ring",
- "sct 0.6.1",
- "webpki 0.21.4",
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.4"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
- "sct 0.7.0",
- "webpki 0.22.0",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -1732,36 +1780,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.0",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "0.2.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
-dependencies = [
- "base64",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
-dependencies = [
- "base64",
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -1785,16 +1815,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sct"
@@ -1837,18 +1857,18 @@ checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1857,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -1879,6 +1899,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb06d4b6cdaef0e0c51fa881acb721bed3c924cfaa71d9c94a3b771dfdf6567"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,41 +1920,26 @@ dependencies = [
  "block-buffer 0.7.3",
  "digest 0.8.1",
  "fake-simd",
- "opaque-debug 0.2.3",
+ "opaque-debug",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
+ "digest 0.10.6",
  "keccak",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "shared_memory"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681a9e90340f748af3a1cc52eb2c040eee29f976b763e99ad90fc0c5df6f9791"
-dependencies = [
- "cfg-if",
- "libc",
- "nix 0.22.3",
- "rand",
- "winapi",
 ]
 
 [[package]]
 name = "shellexpand"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
+checksum = "dd1c7ddea665294d484c39fd0c0d2b7e35bbfe10035c5fe1854741a57f6880e1"
 dependencies = [
- "dirs-next",
+ "dirs",
 ]
 
 [[package]]
@@ -1944,6 +1962,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest 0.10.6",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,9 +1979,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smol"
@@ -1975,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -2000,12 +2028,19 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
+ "base64ct",
  "der",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stop-token"
@@ -2021,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -2033,25 +2068,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2065,12 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -2113,9 +2133,9 @@ version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "libc",
- "mio 0.8.5",
+ "mio",
  "num_cpus",
  "pin-project-lite",
  "socket2",
@@ -2168,17 +2188,24 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uhlc"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d74cc14aac0f650dae365e42250073bc0f89602bad5751d6159642be37690d6"
+checksum = "8d291a7454d390b753ef68df8145da18367e32883ec2fa863959f0aefb915cdb"
 dependencies = [
  "hex",
  "humantime",
  "lazy_static",
  "log",
  "serde",
- "uuid 0.8.2",
+ "spin 0.9.3",
+ "uuid",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2187,16 +2214,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
+name = "unsafe-libyaml"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
 
 [[package]]
 name = "untrusted"
@@ -2217,18 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "uuid"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
  "getrandom",
 ]
@@ -2259,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
 dependencies = [
  "ctor",
  "version_check",
@@ -2375,22 +2387,21 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]
@@ -2501,16 +2512,18 @@ dependencies = [
 
 [[package]]
 name = "zenoh"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44140d6ebcf2e52ee48acad0e9d960c2b1e868eec021da2538e58373d615fc18"
 dependencies = [
  "async-global-executor",
  "async-std",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "env_logger",
  "event-listener",
  "flume",
+ "form_urlencoded",
  "futures",
  "git-version",
  "hex",
@@ -2526,7 +2539,7 @@ dependencies = [
  "socket2",
  "stop-token",
  "uhlc",
- "uuid 0.8.2",
+ "uuid",
  "vec_map",
  "zenoh-buffers",
  "zenoh-cfg-properties",
@@ -2545,23 +2558,21 @@ dependencies = [
 
 [[package]]
 name = "zenoh-buffers"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244d54f1228d3c53fc69483faafcfcc1b4d670b60cffce17696fc49fbc7a6608"
 dependencies = [
  "async-std",
- "bincode",
  "hex",
- "log",
- "serde",
- "shared_memory",
  "zenoh-collections",
  "zenoh-core",
 ]
 
 [[package]]
 name = "zenoh-cfg-properties"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a963395194bf1b64f67d89333e8089f01568ec7ac28c305847f505452a98006e"
 dependencies = [
  "zenoh-core",
  "zenoh-macros",
@@ -2569,8 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-collections"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e256d7aff2c9af765d77efbfae7fcb708d2d7f4e179aa201bff2f81ad7a3845"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2582,15 +2594,16 @@ dependencies = [
 
 [[package]]
 name = "zenoh-config"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad1ff61abf28c57e8879ec4286fa29becf7e9bf12555df9a7faddff3bc9ea1b"
 dependencies = [
  "flume",
  "json5",
  "num_cpus",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.9.17",
  "validated_struct",
  "zenoh-cfg-properties",
  "zenoh-core",
@@ -2600,17 +2613,21 @@ dependencies = [
 
 [[package]]
 name = "zenoh-core"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b0f55158f3f83555db74d4cf5ebc34f90df5d2992cc0de67eba69b99628605e"
 dependencies = [
  "anyhow",
+ "async-std",
  "lazy_static",
+ "zenoh-macros",
 ]
 
 [[package]]
 name = "zenoh-crypto"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653ba15479a0e3f1a94d7f079babc52f742f3a2bd995c59bc250cfc9a789dbbc"
 dependencies = [
  "aes",
  "hmac",
@@ -2622,8 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e58770c73cf0b5ec8fbe104d609eec83f9bc3463ea23a583c8b465de77f7d27"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2641,12 +2659,14 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-commons"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21aab9eeb2aba53e37aae57467ffca1268d209811c5e2f39761aab4c1343bce3"
 dependencies = [
  "async-std",
  "async-trait",
  "flume",
+ "serde",
  "zenoh-buffers",
  "zenoh-cfg-properties",
  "zenoh-core",
@@ -2656,18 +2676,19 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-quic"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f1354094eb4d5e4b864b5aa385efce46f94a43f6ba57dd9ea9a017e6e74176"
 dependencies = [
  "async-std",
  "async-trait",
  "futures",
  "log",
  "quinn",
- "rustls 0.20.4",
+ "rustls",
  "rustls-native-certs",
- "rustls-pemfile 0.3.0",
- "webpki 0.22.0",
+ "rustls-pemfile",
+ "webpki",
  "zenoh-cfg-properties",
  "zenoh-config",
  "zenoh-core",
@@ -2679,8 +2700,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tcp"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ffc29707a50680dba124dd4d8bc3bc19feb158db8312433bfc3078f7b8f1ef"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2694,14 +2716,18 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tls"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a5630b3a218c7179191dab78ebc45da1837793951bddb8fda4f5900b47da552"
 dependencies = [
  "async-rustls",
  "async-std",
  "async-trait",
  "futures",
  "log",
+ "rustls-pemfile",
+ "webpki",
+ "webpki-roots",
  "zenoh-cfg-properties",
  "zenoh-config",
  "zenoh-core",
@@ -2713,8 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-udp"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176494947bd3a6aa10baa469afa4572635822683830808cd71d5554ce15dfebb"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2730,15 +2757,16 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-unixsock_stream"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9974305820f92478490ba8b8f119eb5b7d7b4998a7125d1510f6e69f3f81d1"
 dependencies = [
  "async-std",
  "async-trait",
  "futures",
  "log",
- "nix 0.23.1",
- "uuid 0.8.2",
+ "nix",
+ "uuid",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol-core",
@@ -2747,8 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-macros"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9ac20b120990778cca204ee46c43a37ed4ffbc331e95702615490f9c169de8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2759,8 +2788,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-plugin-trait"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b8bfb8e2625e1150dab46b7a4433f866aa06af763237d564b1aa8f6aaf0b29"
 dependencies = [
  "libloading",
  "log",
@@ -2772,8 +2802,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-protocol"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "174a00456e29d941a4230148fd184953e95883bde47a4cfc1a508e0aaec89a89"
 dependencies = [
  "log",
  "uhlc",
@@ -2784,21 +2815,25 @@ dependencies = [
 
 [[package]]
 name = "zenoh-protocol-core"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf3eaea2095d2c13fefdae25aca813b3644fc15e1441e16a4398b5113033753"
 dependencies = [
  "hex",
+ "itertools",
  "lazy_static",
+ "rand",
  "serde",
  "uhlc",
- "uuid 0.8.2",
+ "uuid",
  "zenoh-core",
 ]
 
 [[package]]
 name = "zenoh-sync"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "821070b62a55d4c8a22e1e06c939c1f2d94767e660df9fcbea377781f72f59bf"
 dependencies = [
  "async-std",
  "event-listener",
@@ -2810,8 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-transport"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4387cfc02cb86383de8e65ab1eb204e3908c5f1db9e6b4defd8ad530c9ddea"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -2821,6 +2857,7 @@ dependencies = [
  "log",
  "paste",
  "rand",
+ "ringbuffer-spsc",
  "rsa",
  "serde",
  "zenoh-buffers",
@@ -2837,8 +2874,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-util"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=d4b00540cd0faa6ce585e11862cf9740ca226489#d4b00540cd0faa6ce585e11862cf9740ca226489"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54646455dad3940535e97cce03f1b604265177349133903d989bc72e00011404"
 dependencies = [
  "async-std",
  "clap",
@@ -2851,6 +2889,7 @@ dependencies = [
  "libloading",
  "log",
  "pnet",
+ "pnet_datalink",
  "shellexpand",
  "winapi",
  "zenoh-cfg-properties",
@@ -2862,21 +2901,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bytes = "1.0.1"
 uuid = { version = "1.0.0", features = ["v4"] }
 smol = "1.2.5"
 rand = "0.8.4"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "d4b00540cd0faa6ce585e11862cf9740ca226489" }
+zenoh = "0.7.0-rc"
 futures = "0.3.15"
 log = "0.4.14"
 fern = "0.6.0"

--- a/api/src/lattice/last_writer_wins.rs
+++ b/api/src/lattice/last_writer_wins.rs
@@ -82,17 +82,21 @@ where
     }
 
     fn merge_element(&mut self, element: &TimestampValuePair<T>) {
-        if element.timestamp > self.element.timestamp {
-            self.element = element.clone();
-        } else if element.timestamp == self.element.timestamp {
-            // TODO: Instead of panicking if values are different, use ar arbitrary
-            // deterministic mechanism to declare a winner. For example, sort by the
-            // raw byte representation of the values. The only requirement is that all
-            // nodes reach the same state, i.e. that the state becomes consistent.
-            assert_eq!(
-                element, &self.element,
-                "merge error: LwwLattices have identical timestamps but different values"
-            );
+        match element.timestamp.cmp(&self.element.timestamp) {
+            std::cmp::Ordering::Greater => {
+                self.element = element.clone();
+            }
+            std::cmp::Ordering::Equal => {
+                // TODO: Instead of panicking if values are different, use ar arbitrary
+                // deterministic mechanism to declare a winner. For example, sort by the
+                // raw byte representation of the values. The only requirement is that all
+                // nodes reach the same state, i.e. that the state becomes consistent.
+                assert_eq!(
+                    element, &self.element,
+                    "merge error: LwwLattices have identical timestamps but different values"
+                );
+            }
+            std::cmp::Ordering::Less => {}
         }
     }
 }

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -68,9 +68,7 @@ fn set_up_logger(thread_id: u32) -> Result<(), fern::InitError> {
         })
         .level(log::LevelFilter::Info)
         .chain(std::io::stdout())
-        .chain(fern::log_file(format!(
-            "benchmark-thread-{thread_id}.log"
-        ))?)
+        .chain(fern::log_file(format!("benchmark-thread-{thread_id}.log"))?)
         .apply()?;
     Ok(())
 }

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -42,7 +42,7 @@ fn main() -> eyre::Result<()> {
 
     let mut input = args
         .input_file
-        .map(|path| File::open(&path).context("failed to open input file"))
+        .map(|path| File::open(path).context("failed to open input file"))
         .transpose()?
         .map(|r| {
             let boxed: Box<dyn Read> = Box::new(r);

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -8,7 +8,7 @@ use std::{
     path::PathBuf,
     sync::Arc,
 };
-use zenoh::prelude::ZFuture;
+use zenoh::prelude::sync::SyncResolve;
 
 #[derive(FromArgs)]
 /// Rusty anna client
@@ -36,7 +36,7 @@ fn main() -> eyre::Result<()> {
     .context("failed to parse config file")?;
 
     let zenoh = zenoh::open(zenoh::config::Config::default())
-        .wait()
+        .res()
         .map_err(|e| eyre::eyre!(e))?;
     let zenoh_prefix = anna_default_zenoh_prefix();
 

--- a/src/bin/kvs.rs
+++ b/src/bin/kvs.rs
@@ -22,7 +22,7 @@ fn main() -> eyre::Result<()> {
     let args: Args = argh::from_env();
 
     let config: Config = serde_yaml::from_str(
-        &fs::read_to_string(&args.config_file).context("failed to read config file")?,
+        &fs::read_to_string(args.config_file).context("failed to read config file")?,
     )
     .context("failed to parse config file")?;
 

--- a/src/bin/kvs.rs
+++ b/src/bin/kvs.rs
@@ -2,7 +2,7 @@ use anna::{anna_default_zenoh_prefix, config::Config, nodes::kvs};
 use argh::FromArgs;
 use eyre::Context;
 use std::{fs, path::PathBuf, sync::Arc};
-use zenoh::prelude::ZFuture;
+use zenoh::prelude::sync::SyncResolve;
 
 #[derive(FromArgs)]
 /// Rusty anna node
@@ -27,7 +27,7 @@ fn main() -> eyre::Result<()> {
     .context("failed to parse config file")?;
 
     let zenoh = zenoh::open(zenoh::config::Config::default())
-        .wait()
+        .res()
         .map_err(|e| eyre::eyre!(e))?;
     let zenoh_prefix = anna_default_zenoh_prefix();
 

--- a/src/bin/logger.rs
+++ b/src/bin/logger.rs
@@ -3,8 +3,8 @@ use zenoh::prelude::{sync::SyncResolve, SplitBuffer};
 fn main() {
     let zenoh = zenoh::open(zenoh::config::Config::default()).res().unwrap();
 
-    let topic = std::env::args().skip(1).next().unwrap_or("**".into());
-    let mut sub = zenoh.declare_subscriber(topic).res().unwrap();
+    let topic = std::env::args().nth(1).unwrap_or("**".into());
+    let sub = zenoh.declare_subscriber(topic).res().unwrap();
 
     for sample in sub.receiver.iter() {
         let value = match String::from_utf8(sample.value.payload.contiguous().into_owned()) {
@@ -14,9 +14,7 @@ fn main() {
 
         let value_shortened = if value.len() > 500 {
             let index = (0..500)
-                .rev()
-                .filter(|&i| value.is_char_boundary(i))
-                .next()
+                .rev().find(|&i| value.is_char_boundary(i))
                 .unwrap();
             &value[..index]
         } else {

--- a/src/bin/logger.rs
+++ b/src/bin/logger.rs
@@ -3,7 +3,7 @@ use zenoh::prelude::{sync::SyncResolve, SplitBuffer};
 fn main() {
     let zenoh = zenoh::open(zenoh::config::Config::default()).res().unwrap();
 
-    let topic = std::env::args().skip(1).next().unwrap_or("/**".into());
+    let topic = std::env::args().skip(1).next().unwrap_or("**".into());
     let mut sub = zenoh.declare_subscriber(topic).res().unwrap();
 
     for sample in sub.receiver.iter() {

--- a/src/bin/logger.rs
+++ b/src/bin/logger.rs
@@ -1,14 +1,12 @@
-use zenoh::prelude::{SplitBuffer, ZFuture};
+use zenoh::prelude::{sync::SyncResolve, SplitBuffer};
 
 fn main() {
-    let zenoh = zenoh::open(zenoh::config::Config::default())
-        .wait()
-        .unwrap();
+    let zenoh = zenoh::open(zenoh::config::Config::default()).res().unwrap();
 
     let topic = std::env::args().skip(1).next().unwrap_or("/**".into());
-    let mut sub = zenoh.subscribe(topic).wait().unwrap();
+    let mut sub = zenoh.declare_subscriber(topic).res().unwrap();
 
-    for sample in sub.receiver().iter() {
+    for sample in sub.receiver.iter() {
         let value = match String::from_utf8(sample.value.payload.contiguous().into_owned()) {
             Err(_) => "<invalid UTF8>".to_string(),
             Ok(v) => v.to_string(),

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -2,7 +2,7 @@ use anna::{anna_default_zenoh_prefix, config::Config, nodes::monitoring};
 use argh::FromArgs;
 use eyre::Context;
 use std::{fs, path::PathBuf, sync::Arc};
-use zenoh::prelude::ZFuture;
+use zenoh::prelude::sync::SyncResolve;
 
 #[derive(FromArgs)]
 /// Rusty anna monitor
@@ -27,7 +27,7 @@ fn main() -> eyre::Result<()> {
     .context("failed to parse config file")?;
 
     let zenoh = zenoh::open(zenoh::config::Config::default())
-        .wait()
+        .res()
         .map_err(|e| eyre::eyre!(e))?;
     let zenoh_prefix = anna_default_zenoh_prefix();
 

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -22,7 +22,7 @@ fn main() -> eyre::Result<()> {
     let args: Args = argh::from_env();
 
     let config: Config = serde_yaml::from_str(
-        &fs::read_to_string(&args.config_file).context("failed to read config file")?,
+        &fs::read_to_string(args.config_file).context("failed to read config file")?,
     )
     .context("failed to parse config file")?;
 

--- a/src/bin/routing.rs
+++ b/src/bin/routing.rs
@@ -22,7 +22,7 @@ fn main() -> eyre::Result<()> {
     let args: Args = argh::from_env();
 
     let config: Config = serde_yaml::from_str(
-        &fs::read_to_string(&args.config_file).context("failed to read config file")?,
+        &fs::read_to_string(args.config_file).context("failed to read config file")?,
     )
     .context("failed to parse config file")?;
 

--- a/src/bin/routing.rs
+++ b/src/bin/routing.rs
@@ -2,7 +2,7 @@ use anna::{anna_default_zenoh_prefix, config::Config, nodes::routing};
 use argh::FromArgs;
 use eyre::Context;
 use std::{fs, path::PathBuf, sync::Arc};
-use zenoh::prelude::ZFuture;
+use zenoh::prelude::sync::SyncResolve;
 
 #[derive(FromArgs)]
 /// Rusty anna router
@@ -27,7 +27,7 @@ fn main() -> eyre::Result<()> {
     .context("failed to parse config file")?;
 
     let zenoh = zenoh::open(zenoh::config::Config::default())
-        .wait()
+        .res()
         .map_err(|e| eyre::eyre!(e))?;
     let zenoh_prefix = anna_default_zenoh_prefix();
 

--- a/src/bin/send-benchmark-commands.rs
+++ b/src/bin/send-benchmark-commands.rs
@@ -128,7 +128,7 @@ fn main() -> eyre::Result<()> {
                 .map_err(|e| eyre::eyre!(e))?;
         }
         Command::Exit(ExitCommand {}) => {
-            let serialized = format!("EXIT");
+            let serialized = "EXIT".to_string();
             zenoh
                 .put(&benchmark_topic(args.thread_id, zenoh_prefix), serialized)
                 .res()

--- a/src/hash_ring/mod.rs
+++ b/src/hash_ring/mod.rs
@@ -171,6 +171,7 @@ impl HashRingUtil {
     /// that corresponds to the given `key`. The response will be sent to the
     /// specified `response_address`. The hash ring parameters are needed for finding
     /// the responsible threads.
+    #[allow(clippy::too_many_arguments)]
     pub async fn issue_replication_factor_request(
         &self,
         response_address: String,

--- a/src/hash_ring/mod.rs
+++ b/src/hash_ring/mod.rs
@@ -12,6 +12,7 @@ use eyre::{anyhow, eyre, Context};
 use rand::prelude::SliceRandom;
 use smol::net::TcpStream;
 use std::collections::{HashMap, HashSet};
+use zenoh::prelude::r#async::AsyncResolve;
 
 mod consistent_hash_map;
 
@@ -212,6 +213,7 @@ impl HashRingUtil {
 
             zenoh
                 .put(&target_address, serialized)
+                .res()
                 .await
                 .map_err(|e| eyre!(e))
                 .context("failed to send replication factor request")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub use anna_api::{lattice, AnnaError, ClientKey};
 use eyre::anyhow;
 use messages::Tier;
 use metadata::MetadataKey;
-use zenoh::prelude::{SplitBuffer, ZFuture};
+use zenoh::prelude::SplitBuffer;
 
 pub mod nodes;
 
@@ -107,9 +107,10 @@ pub fn zenoh_test_instance() -> Arc<zenoh::Session> {
     static TEST_ZENOH: once_cell::sync::Lazy<Arc<zenoh::Session>> =
         once_cell::sync::Lazy::new(|| {
             Arc::new(
-                zenoh::open(zenoh::config::Config::default())
-                    .wait()
-                    .expect("failed to open zenoh session"),
+                zenoh::prelude::sync::SyncResolve::res(zenoh::open(
+                    zenoh::config::Config::default(),
+                ))
+                .expect("failed to open zenoh session"),
             )
         });
     TEST_ZENOH.clone()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ impl std::convert::TryFrom<Key> for ClientKey {
 
 /// The default topic prefix for zenoh, used by the executables.
 pub fn anna_default_zenoh_prefix() -> &'static str {
-    "/anna"
+    "anna"
 }
 
 /// Helper trait for converting a [`zenoh::Value`] to string types.

--- a/src/nodes/client/interactive.rs
+++ b/src/nodes/client/interactive.rs
@@ -119,7 +119,7 @@ impl ClientNode {
                 "quit" | "exit" | "q" => break,
                 _ => {
                     if let Err(err) = self.handle_interactive_request(input, stdout) {
-                        writeln!(stderr, "Error: {:#}", err)?;
+                        writeln!(stderr, "Error: {err:#}")?;
                         if fail_fast {
                             bail!(err);
                         }
@@ -170,7 +170,7 @@ impl ClientNode {
                 let string = String::from_utf8(value).context("value is not valid utf8")?;
 
                 log::trace!("[OK] Got {} from GET", string);
-                writeln!(stdout, "{}", string)?;
+                writeln!(stdout, "{string}")?;
             }
             "PUT_SET" | "put_set" => {
                 let key = split
@@ -231,7 +231,7 @@ impl ClientNode {
                 }
 
                 for (k, v) in mkcl.dependencies.reveal() {
-                    write!(stdout, "{} : ", k)?;
+                    write!(stdout, "{k} : ")?;
                     for vc_pair in v.reveal() {
                         writeln!(stdout, "{{{} : {}}}", vc_pair.0, vc_pair.1.reveal())?;
                     }

--- a/src/nodes/client/interactive.rs
+++ b/src/nodes/client/interactive.rs
@@ -20,7 +20,7 @@ use std::{
 /// for testing.
 ///
 /// To communicate with routing and KVS nodes, the client uses the given zenoh workspace.
-pub fn run_interactive<'a>(
+pub fn run_interactive(
     config: &Config,
     stdin: &mut dyn Read,
     stdout: &mut dyn Write,

--- a/src/nodes/client/mod.rs
+++ b/src/nodes/client/mod.rs
@@ -125,7 +125,7 @@ impl ClientNode {
             let zenoh = zenoh.clone();
             let (tx, rx) = channel::bounded(10);
             receive_tasks.push(Box::pin(async move {
-                let mut changes = zenoh
+                let changes = zenoh
                     .declare_subscriber(topic)
                     .res()
                     .await
@@ -300,7 +300,7 @@ impl ClientNode {
         let request = ClientRequest {
             key,
             put_value: Some(lattice),
-            response_address: self.ut.response_topic(&self.zenoh_prefix).to_string(),
+            response_address: self.ut.response_topic(&self.zenoh_prefix),
             request_id: request_id.clone(),
             address_cache_size: HashMap::new(),
             timestamp: Instant::now(),
@@ -327,7 +327,7 @@ impl ClientNode {
         let request = ClientRequest {
             key,
             put_value: None,
-            response_address: self.ut.response_topic(&self.zenoh_prefix).to_string(),
+            response_address: self.ut.response_topic(&self.zenoh_prefix),
             request_id: request_id.clone(),
             address_cache_size: HashMap::new(),
             timestamp: Instant::now(),
@@ -753,7 +753,7 @@ impl ClientNode {
             response_address: self
                 .ut
                 .address_response_topic(&self.zenoh_prefix)
-                .to_string(),
+                ,
             keys: vec![key.clone()],
         };
 

--- a/src/nodes/kvs/gossip.rs
+++ b/src/nodes/kvs/gossip.rs
@@ -17,6 +17,7 @@ use std::{
     convert::TryFrom,
     time::{Duration, Instant},
 };
+use zenoh::prelude::r#async::AsyncResolve;
 
 // Define the data redistribute threshold
 const DATA_REDISTRIBUTE_THRESHOLD: usize = 50;
@@ -192,6 +193,7 @@ impl KvsNode {
                     .context("failed to serialize report Request message")?;
                 self.zenoh
                     .put(&target_address, serialized)
+                    .res()
                     .await
                     .map_err(|e| eyre!(e))?;
             }
@@ -231,6 +233,7 @@ impl KvsNode {
                 serde_json::to_string(&msg).context("failed to serialize KeyRequest")?;
             self.zenoh
                 .put(&addr.clone(), serialized)
+                .res()
                 .await
                 .map_err(|e| eyre!(e))
                 .context("failed to send gossip message")?;

--- a/src/nodes/kvs/handlers/gossip.rs
+++ b/src/nodes/kvs/handlers/gossip.rs
@@ -139,7 +139,7 @@ mod tests {
             response_address: Some(
                 ClientThread::new(node_id, 0)
                     .response_topic(zenoh_prefix)
-                    .to_string(),
+                    ,
             ),
             request_id: Some("0".to_owned()),
             address_cache_size: Default::default(),
@@ -186,7 +186,7 @@ mod tests {
         let key: ClientKey = "key".into();
         let mut value = "value1".as_bytes().to_owned();
 
-        let mut server = kvs_test_instance(zenoh.clone(), zenoh_prefix.clone());
+        let mut server = kvs_test_instance(zenoh, zenoh_prefix.clone());
         server.key_replication_map.entry(key.clone()).or_default();
         server
             .kvs

--- a/src/nodes/kvs/handlers/gossip.rs
+++ b/src/nodes/kvs/handlers/gossip.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use eyre::{bail, Context};
 use std::{collections::HashMap, time::Instant};
+use zenoh::prelude::r#async::AsyncResolve;
 
 impl KvsNode {
     /// Handles incoming gossip messages.
@@ -98,6 +99,7 @@ impl KvsNode {
                 serde_json::to_string(&key_request).context("failed to serialize KeyRequest")?;
             self.zenoh
                 .put(&address, serialized)
+                .res()
                 .await
                 .map_err(|e| eyre::eyre!(e))?;
         }

--- a/src/nodes/kvs/handlers/management_node_response.rs
+++ b/src/nodes/kvs/handlers/management_node_response.rs
@@ -7,6 +7,7 @@ use eyre::Context;
 
 use rand::prelude::SliceRandom;
 use std::{collections::HashMap, mem, time::Instant};
+use zenoh::prelude::r#async::AsyncResolve;
 
 impl KvsNode {
     /// Handles incoming management node responses.
@@ -83,6 +84,7 @@ impl KvsNode {
                 serde_json::to_string(&request).context("failed to serialize KeyRequest")?;
             self.zenoh
                 .put(&address, serialized_req)
+                .res()
                 .await
                 .map_err(|e| eyre::eyre!(e))?;
         }

--- a/src/nodes/kvs/handlers/node_depart.rs
+++ b/src/nodes/kvs/handlers/node_depart.rs
@@ -77,8 +77,8 @@ mod tests {
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
 
         let zenoh_clone = zenoh.clone();
-        let mut subscriber = zenoh_clone
-            .declare_subscriber(format!("{}/**", zenoh_prefix))
+        let subscriber = zenoh_clone
+            .declare_subscriber(format!("{zenoh_prefix}/**"))
             .res()
             .unwrap();
 

--- a/src/nodes/kvs/handlers/node_depart.rs
+++ b/src/nodes/kvs/handlers/node_depart.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use eyre::Context;
+use zenoh::prelude::r#async::AsyncResolve;
 
 use crate::{hash_ring::tier_name, messages, nodes::kvs::KvsNode, topics::KvsThread};
 
@@ -37,6 +38,7 @@ impl KvsNode {
                             .node_depart_topic(&self.zenoh_prefix),
                         serialized.as_str(),
                     )
+                    .res()
                     .await
                     .map_err(|e| eyre::eyre!(e))?;
             }
@@ -59,7 +61,8 @@ impl KvsNode {
 
 #[cfg(test)]
 mod tests {
-    use zenoh::prelude::{Receiver, ZFuture};
+
+    use zenoh::prelude::sync::SyncResolve;
 
     use crate::{
         messages::{self, Tier},
@@ -75,8 +78,8 @@ mod tests {
 
         let zenoh_clone = zenoh.clone();
         let mut subscriber = zenoh_clone
-            .subscribe(format!("{}/**", zenoh_prefix))
-            .wait()
+            .declare_subscriber(format!("{}/**", zenoh_prefix))
+            .res()
             .unwrap();
 
         let mut server = kvs_test_instance(zenoh, zenoh_prefix);
@@ -102,7 +105,7 @@ mod tests {
         smol::block_on(server.node_depart_handler(departed.clone())).unwrap();
 
         let message = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(5))
             .unwrap();
         let message_parsed: messages::Departed =

--- a/src/nodes/kvs/handlers/node_join.rs
+++ b/src/nodes/kvs/handlers/node_join.rs
@@ -177,8 +177,8 @@ mod tests {
     fn basic_node_join() {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
-        let mut subscriber = zenoh
-            .declare_subscriber(format!("{}/**", zenoh_prefix))
+        let subscriber = zenoh
+            .declare_subscriber(format!("{zenoh_prefix}/**"))
             .res()
             .unwrap();
 
@@ -235,7 +235,7 @@ mod tests {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
 
-        let mut server = kvs_test_instance(zenoh.clone(), zenoh_prefix);
+        let mut server = kvs_test_instance(zenoh, zenoh_prefix);
 
         assert_eq!(server.global_hash_rings[&Tier::Memory].len(), 3000);
         assert_eq!(

--- a/src/nodes/kvs/handlers/node_join.rs
+++ b/src/nodes/kvs/handlers/node_join.rs
@@ -1,6 +1,7 @@
 use crate::{hash_ring::tier_name, messages, nodes::kvs::KvsNode, topics::KvsThread};
 use eyre::Context;
 use std::time::Instant;
+use zenoh::prelude::r#async::AsyncResolve;
 
 impl KvsNode {
     /// Handles incoming node join messages.
@@ -47,6 +48,7 @@ impl KvsNode {
                             .node_join_topic(&self.zenoh_prefix),
                         msg.as_str(),
                     )
+                    .res()
                     .await
                     .map_err(|e| eyre::eyre!(e))
                     .context("failed to send ip to new server node")?;
@@ -61,7 +63,7 @@ impl KvsNode {
                                 .put(
                                     &KvsThread::new(node_id.clone(), 0).node_join_topic(&self.zenoh_prefix),
                                     serialized.as_str(),
-                                )
+                                ).res()
                                 .await
                                 .map_err(|e| eyre::eyre!(e))
                                 .context(
@@ -85,6 +87,7 @@ impl KvsNode {
                                 .node_join_topic(&self.zenoh_prefix),
                             serialized.as_str(),
                         )
+                        .res()
                         .await
                         .map_err(|e| eyre::eyre!(e))
                         .context("failed to send ip of new server node to workers")?;
@@ -160,7 +163,8 @@ impl KvsNode {
 
 #[cfg(test)]
 mod tests {
-    use zenoh::prelude::{Receiver, ZFuture};
+
+    use zenoh::prelude::sync::SyncResolve;
 
     use crate::{
         messages::{self, Tier},
@@ -174,8 +178,8 @@ mod tests {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
         let mut subscriber = zenoh
-            .subscribe(format!("{}/**", zenoh_prefix))
-            .wait()
+            .declare_subscriber(format!("{}/**", zenoh_prefix))
+            .res()
             .unwrap();
 
         let mut server = kvs_test_instance(zenoh.clone(), zenoh_prefix);
@@ -198,7 +202,7 @@ mod tests {
 
         let message_1: messages::Join = {
             let raw = subscriber
-                .receiver()
+                .receiver
                 .recv_timeout(Duration::from_secs(5))
                 .unwrap();
             serde_json::from_str(&raw.value.as_string().unwrap()).unwrap()
@@ -212,7 +216,7 @@ mod tests {
             },
         );
         let message_2 = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(5))
             .unwrap();
         let message_2_parsed: messages::Join =

--- a/src/nodes/kvs/handlers/replication_change.rs
+++ b/src/nodes/kvs/handlers/replication_change.rs
@@ -3,6 +3,7 @@ use crate::{
     Key, ALL_TIERS,
 };
 use eyre::Context;
+use zenoh::prelude::r#async::AsyncResolve;
 
 use std::{
     collections::{HashMap, HashSet},
@@ -24,6 +25,7 @@ impl KvsNode {
                             .replication_change_topic(&self.zenoh_prefix),
                         serialized,
                     )
+                    .res()
                     .await
                     .map_err(|e| eyre::eyre!(e))?;
             }

--- a/src/nodes/kvs/handlers/replication_response.rs
+++ b/src/nodes/kvs/handlers/replication_response.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use eyre::{anyhow, bail, Context};
 use std::{collections::HashMap, time::Instant};
+use zenoh::prelude::r#async::AsyncResolve;
 
 impl KvsNode {
     /// Handles incoming replication response messages.
@@ -158,6 +159,7 @@ impl KvsNode {
                                 .context("failed to serialize key response")?;
                             self.zenoh
                                 .put(request_addr, serialized_response)
+                                .res()
                                 .await
                                 .map_err(|e| eyre::eyre!(e))?;
                         }
@@ -238,6 +240,7 @@ impl KvsNode {
                             .context("failed to serialize KeyRequest")?;
                         self.zenoh
                             .put(&address, serialized)
+                            .res()
                             .await
                             .map_err(|e| eyre::eyre!(e))?;
                     }

--- a/src/nodes/kvs/handlers/request.rs
+++ b/src/nodes/kvs/handlers/request.rs
@@ -206,7 +206,7 @@ mod tests {
             response_address: Some(
                 ClientThread::new(node_id, 0)
                     .response_topic(zenoh_prefix)
-                    .to_string(),
+                    ,
             ),
             request_id: Some(request_id),
             address_cache_size: Default::default(),
@@ -230,7 +230,7 @@ mod tests {
             response_address: Some(
                 ClientThread::new(node_id, 0)
                     .response_topic(zenoh_prefix)
-                    .to_string(),
+                    ,
             ),
             request_id: Some(request_id),
             address_cache_size: Default::default(),
@@ -241,8 +241,8 @@ mod tests {
     fn user_get_lww_test() {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
-        let mut subscriber = zenoh
-            .declare_subscriber(format!("{}/**", zenoh_prefix))
+        let subscriber = zenoh
+            .declare_subscriber(format!("{zenoh_prefix}/**"))
             .res()
             .unwrap();
 
@@ -291,8 +291,8 @@ mod tests {
     fn user_get_set_test() {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
-        let mut subscriber = zenoh
-            .declare_subscriber(format!("{}/**", zenoh_prefix))
+        let subscriber = zenoh
+            .declare_subscriber(format!("{zenoh_prefix}/**"))
             .res()
             .unwrap();
 
@@ -350,8 +350,8 @@ mod tests {
     fn user_get_ordered_set_test() {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
-        let mut subscriber = zenoh
-            .declare_subscriber(format!("{}/**", zenoh_prefix))
+        let subscriber = zenoh
+            .declare_subscriber(format!("{zenoh_prefix}/**"))
             .res()
             .unwrap();
 
@@ -413,8 +413,8 @@ mod tests {
     fn user_get_causal_test() {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
-        let mut subscriber = zenoh
-            .declare_subscriber(format!("{}/**", zenoh_prefix))
+        let subscriber = zenoh
+            .declare_subscriber(format!("{zenoh_prefix}/**"))
             .res()
             .unwrap();
 
@@ -481,8 +481,8 @@ mod tests {
     fn user_put_and_get_lww_test() {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
-        let mut subscriber = zenoh
-            .declare_subscriber(format!("{}/**", zenoh_prefix))
+        let subscriber = zenoh
+            .declare_subscriber(format!("{zenoh_prefix}/**"))
             .res()
             .unwrap();
 
@@ -561,8 +561,8 @@ mod tests {
     fn user_put_and_get_set_test() {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
-        let mut subscriber = zenoh
-            .declare_subscriber(format!("{}/**", zenoh_prefix))
+        let subscriber = zenoh
+            .declare_subscriber(format!("{zenoh_prefix}/**"))
             .res()
             .unwrap();
 
@@ -641,8 +641,8 @@ mod tests {
     fn user_put_and_get_ordered_set_test() {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
-        let mut subscriber = zenoh
-            .declare_subscriber(format!("{}/**", zenoh_prefix))
+        let subscriber = zenoh
+            .declare_subscriber(format!("{zenoh_prefix}/**"))
             .res()
             .unwrap();
 
@@ -729,8 +729,8 @@ mod tests {
     fn user_put_and_get_causal_test() {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
-        let mut subscriber = zenoh
-            .declare_subscriber(format!("{}/**", zenoh_prefix))
+        let subscriber = zenoh
+            .declare_subscriber(format!("{zenoh_prefix}/**"))
             .res()
             .unwrap();
 

--- a/src/nodes/kvs/handlers/request.rs
+++ b/src/nodes/kvs/handlers/request.rs
@@ -9,6 +9,7 @@ use crate::{
 use eyre::Context;
 use smol::net::TcpStream;
 use std::time::Instant;
+use zenoh::prelude::r#async::AsyncResolve;
 
 impl KvsNode {
     /// Handles incoming request messages.
@@ -155,6 +156,7 @@ impl KvsNode {
                         .context("failed to serialize key response")?;
                     self.zenoh
                         .put(&response_addr, serialized_response)
+                        .res()
                         .await
                         .map_err(|e| eyre::eyre!(e))?;
                 }
@@ -167,7 +169,8 @@ impl KvsNode {
 
 #[cfg(test)]
 mod tests {
-    use zenoh::prelude::{Receiver, ZFuture};
+
+    use zenoh::prelude::sync::SyncResolve;
 
     use crate::{
         lattice::{
@@ -239,8 +242,8 @@ mod tests {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
         let mut subscriber = zenoh
-            .subscribe(format!("{}/**", zenoh_prefix))
-            .wait()
+            .declare_subscriber(format!("{}/**", zenoh_prefix))
+            .res()
             .unwrap();
 
         let mut server = kvs_test_instance(zenoh.clone(), zenoh_prefix.clone());
@@ -264,7 +267,7 @@ mod tests {
         smol::block_on(server.request_handler(get_request, None)).unwrap();
 
         let message = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(5))
             .unwrap();
 
@@ -289,8 +292,8 @@ mod tests {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
         let mut subscriber = zenoh
-            .subscribe(format!("{}/**", zenoh_prefix))
-            .wait()
+            .declare_subscriber(format!("{}/**", zenoh_prefix))
+            .res()
             .unwrap();
 
         let mut server = kvs_test_instance(zenoh.clone(), zenoh_prefix.clone());
@@ -320,7 +323,7 @@ mod tests {
         smol::block_on(server.request_handler(get_request, None)).unwrap();
 
         let message = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(5))
             .unwrap();
 
@@ -348,8 +351,8 @@ mod tests {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
         let mut subscriber = zenoh
-            .subscribe(format!("{}/**", zenoh_prefix))
-            .wait()
+            .declare_subscriber(format!("{}/**", zenoh_prefix))
+            .res()
             .unwrap();
 
         let mut server = kvs_test_instance(zenoh.clone(), zenoh_prefix.clone());
@@ -383,7 +386,7 @@ mod tests {
         smol::block_on(server.request_handler(get_request, None)).unwrap();
 
         let message = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(10))
             .unwrap();
 
@@ -411,8 +414,8 @@ mod tests {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
         let mut subscriber = zenoh
-            .subscribe(format!("{}/**", zenoh_prefix))
-            .wait()
+            .declare_subscriber(format!("{}/**", zenoh_prefix))
+            .res()
             .unwrap();
 
         let key: ClientKey = "key".into();
@@ -452,7 +455,7 @@ mod tests {
         smol::block_on(server.request_handler(get_request, None)).unwrap();
 
         let message = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(10))
             .unwrap();
         let response: Response = serde_json::from_str(&message.value.as_string().unwrap()).unwrap();
@@ -479,8 +482,8 @@ mod tests {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
         let mut subscriber = zenoh
-            .subscribe(format!("{}/**", zenoh_prefix))
-            .wait()
+            .declare_subscriber(format!("{}/**", zenoh_prefix))
+            .res()
             .unwrap();
 
         let key: ClientKey = "key".into();
@@ -504,7 +507,7 @@ mod tests {
         smol::block_on(server.request_handler(put_request, None)).unwrap();
 
         let message = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(10))
             .unwrap();
         let response: Response = serde_json::from_str(&message.value.as_string().unwrap()).unwrap();
@@ -532,7 +535,7 @@ mod tests {
         smol::block_on(server.request_handler(get_request, None)).unwrap();
 
         let message = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(10))
             .unwrap();
         let response: Response = serde_json::from_str(&message.value.as_string().unwrap()).unwrap();
@@ -559,8 +562,8 @@ mod tests {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
         let mut subscriber = zenoh
-            .subscribe(format!("{}/**", zenoh_prefix))
-            .wait()
+            .declare_subscriber(format!("{}/**", zenoh_prefix))
+            .res()
             .unwrap();
 
         let key: ClientKey = "key".into();
@@ -587,7 +590,7 @@ mod tests {
         smol::block_on(server.request_handler(put_request, None)).unwrap();
 
         let message = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(10))
             .unwrap();
         let response: Response = serde_json::from_str(&message.value.as_string().unwrap()).unwrap();
@@ -615,7 +618,7 @@ mod tests {
         smol::block_on(server.request_handler(get_request, None)).unwrap();
 
         let message = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(10))
             .unwrap();
         let response: Response = serde_json::from_str(&message.value.as_string().unwrap()).unwrap();
@@ -639,8 +642,8 @@ mod tests {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
         let mut subscriber = zenoh
-            .subscribe(format!("{}/**", zenoh_prefix))
-            .wait()
+            .declare_subscriber(format!("{}/**", zenoh_prefix))
+            .res()
             .unwrap();
 
         let key: ClientKey = "key".into();
@@ -667,7 +670,7 @@ mod tests {
         smol::block_on(server.request_handler(put_request, None)).unwrap();
 
         let message = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(10))
             .unwrap();
         let response: Response = serde_json::from_str(&message.value.as_string().unwrap()).unwrap();
@@ -695,7 +698,7 @@ mod tests {
         smol::block_on(server.request_handler(get_request, None)).unwrap();
 
         let message = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(10))
             .unwrap();
         let response: Response = serde_json::from_str(&message.value.as_string().unwrap()).unwrap();
@@ -727,8 +730,8 @@ mod tests {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
         let mut subscriber = zenoh
-            .subscribe(format!("{}/**", zenoh_prefix))
-            .wait()
+            .declare_subscriber(format!("{}/**", zenoh_prefix))
+            .res()
             .unwrap();
 
         let key: ClientKey = "key".into();
@@ -761,7 +764,7 @@ mod tests {
         smol::block_on(server.request_handler(put_request, None)).unwrap();
 
         let message = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(10))
             .unwrap();
         let response: Response = serde_json::from_str(&message.value.as_string().unwrap()).unwrap();
@@ -789,7 +792,7 @@ mod tests {
         smol::block_on(server.request_handler(get_request, None)).unwrap();
 
         let message = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(10))
             .unwrap();
         let response: Response = serde_json::from_str(&message.value.as_string().unwrap()).unwrap();

--- a/src/nodes/kvs/handlers/self_depart.rs
+++ b/src/nodes/kvs/handlers/self_depart.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use eyre::Context;
 use std::collections::{HashMap, HashSet};
+use zenoh::prelude::r#async::AsyncResolve;
 
 impl KvsNode {
     /// Handles incoming self depart messages.
@@ -37,6 +38,7 @@ impl KvsNode {
                             serde_json::to_string(&depart_message)
                                 .context("failed to serialize depart message")?,
                         )
+                        .res()
                         .await
                         .map_err(|e| eyre::eyre!(e))?;
                 }
@@ -52,6 +54,7 @@ impl KvsNode {
                         &RoutingThread::new(node_id.clone(), 0).notify_topic(&self.zenoh_prefix),
                         notify_message.as_str(),
                     )
+                    .res()
                     .await
                     .map_err(|e| eyre::eyre!(e))?;
             }
@@ -62,6 +65,7 @@ impl KvsNode {
                     &MonitoringThread::notify_topic(&self.zenoh_prefix),
                     notify_message.as_str(),
                 )
+                .res()
                 .await
                 .map_err(|e| eyre::eyre!(e))?;
 
@@ -73,6 +77,7 @@ impl KvsNode {
                             .self_depart_topic(&self.zenoh_prefix),
                         serialized,
                     )
+                    .res()
                     .await
                     .map_err(|e| eyre::eyre!(e))?;
             }
@@ -119,6 +124,7 @@ impl KvsNode {
                     node_id: self.node_id.clone(),
                 })?,
             )
+            .res()
             .await
             .map_err(|e| eyre::eyre!(e))?;
 
@@ -129,7 +135,8 @@ impl KvsNode {
 
 #[cfg(test)]
 mod tests {
-    use zenoh::prelude::{Receiver, ZFuture};
+
+    use zenoh::prelude::sync::SyncResolve;
 
     use crate::{
         messages::{Departed, SelfDepart, Tier},
@@ -146,7 +153,10 @@ mod tests {
             response_topic: format!("{}/self_depart_test_response_address", zenoh_prefix),
         };
 
-        let mut subscriber = zenoh.subscribe(&self_depart.response_topic).wait().unwrap();
+        let mut subscriber = zenoh
+            .declare_subscriber(&self_depart.response_topic)
+            .res()
+            .unwrap();
 
         let mut server = kvs_test_instance(zenoh.clone(), zenoh_prefix.clone());
         assert_eq!(server.global_hash_rings[&Tier::Memory].len(), 3000);
@@ -158,7 +168,7 @@ mod tests {
         smol::block_on(server.self_depart_handler(&serialized)).unwrap();
 
         let message = subscriber
-            .receiver()
+            .receiver
             .recv_timeout(Duration::from_secs(5))
             .unwrap();
 
@@ -168,10 +178,7 @@ mod tests {
             0
         );
 
-        assert_eq!(
-            message.key_expr.try_as_str().unwrap(),
-            self_depart.response_topic
-        );
+        assert_eq!(message.key_expr.as_str(), self_depart.response_topic);
         let depart_msg: Departed =
             serde_json::from_str(&message.value.as_string().unwrap()).unwrap();
         assert_eq!(

--- a/src/nodes/kvs/handlers/self_depart.rs
+++ b/src/nodes/kvs/handlers/self_depart.rs
@@ -150,15 +150,15 @@ mod tests {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
         let self_depart = SelfDepart {
-            response_topic: format!("{}/self_depart_test_response_address", zenoh_prefix),
+            response_topic: format!("{zenoh_prefix}/self_depart_test_response_address"),
         };
 
-        let mut subscriber = zenoh
+        let subscriber = zenoh
             .declare_subscriber(&self_depart.response_topic)
             .res()
             .unwrap();
 
-        let mut server = kvs_test_instance(zenoh.clone(), zenoh_prefix.clone());
+        let mut server = kvs_test_instance(zenoh.clone(), zenoh_prefix);
         assert_eq!(server.global_hash_rings[&Tier::Memory].len(), 3000);
         assert_eq!(
             server.global_hash_rings[&Tier::Memory].unique_nodes().len(),

--- a/src/nodes/kvs/mod.rs
+++ b/src/nodes/kvs/mod.rs
@@ -120,7 +120,7 @@ pub fn run(
                 .await?;
                 node.run(shutdown.next().map(|_| ()))
                     .await
-                    .context(format!("KVS thread {}/{} failed", node_id, thread_id))
+                    .context(format!("KVS thread {node_id}/{thread_id} failed"))
             };
             s.spawn(move |_| {
                 smol::block_on(async {

--- a/src/nodes/kvs/mod.rs
+++ b/src/nodes/kvs/mod.rs
@@ -770,7 +770,7 @@ struct PendingGossip {
 }
 
 #[cfg(test)]
-fn kvs_test_instance<'a>(zenoh: Arc<zenoh::Session>, zenoh_prefix: String) -> KvsNode {
+fn kvs_test_instance(zenoh: Arc<zenoh::Session>, zenoh_prefix: String) -> KvsNode {
     let config_data = ConfigData {
         self_tier: Tier::Memory,
         thread_num: 1,

--- a/src/nodes/kvs/mod.rs
+++ b/src/nodes/kvs/mod.rs
@@ -27,6 +27,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
+use zenoh::prelude::r#async::AsyncResolve;
 
 use super::{receive_tcp_message, request_cluster_info, send_tcp_message};
 
@@ -379,6 +380,7 @@ impl KvsNode {
                                 serde_json::to_string(&join_msg)
                                     .context("failed to serialize join message")?,
                             )
+                            .res()
                             .await
                             .map_err(|e| eyre!(e))
                             .context("failed to send join message to servers")?;
@@ -396,6 +398,7 @@ impl KvsNode {
                         &RoutingThread::new(node_id.clone(), 0).notify_topic(&self.zenoh_prefix),
                         notify_msg.as_str(),
                     )
+                    .res()
                     .await
                     .map_err(|e| eyre!(e))
                     .context("failed to send join message to routing nodes")?;
@@ -407,6 +410,7 @@ impl KvsNode {
                     &MonitoringThread::notify_topic(&self.zenoh_prefix),
                     notify_msg.as_str(),
                 )
+                .res()
                 .await
                 .map_err(|e| eyre!(e))
                 .context("failed to send join message to monitoring nodes")?;
@@ -415,77 +419,87 @@ impl KvsNode {
         let zenoh = self.zenoh.clone();
 
         // listens for a new node joining
-        let mut join_subscriber = zenoh
-            .subscribe(&self.wt.node_join_topic(&self.zenoh_prefix))
+        let join_subscriber = zenoh
+            .declare_subscriber(&self.wt.node_join_topic(&self.zenoh_prefix))
+            .res()
             .await
             .map_err(|e| eyre!(e))
             .context("failed to declare join subscriber")?;
-        let mut join_stream = join_subscriber.receiver().fuse();
+        let mut join_stream = join_subscriber.receiver.into_stream();
 
         // listens for a node departing
-        let mut depart_subscriber = zenoh
-            .subscribe(&self.wt.node_depart_topic(&self.zenoh_prefix))
+        let depart_subscriber = zenoh
+            .declare_subscriber(&self.wt.node_depart_topic(&self.zenoh_prefix))
+            .res()
             .await
             .map_err(|e| eyre!(e))
             .context("failed to declare depart subscriber")?;
-        let mut depart_stream = depart_subscriber.receiver().fuse();
+        let mut depart_stream = depart_subscriber.receiver.into_stream();
 
         // responsible for listening for a command that this node should leave
-        let mut self_depart_subscriber = zenoh
-            .subscribe(&self.wt.self_depart_topic(&self.zenoh_prefix))
+        let self_depart_subscriber = zenoh
+            .declare_subscriber(&self.wt.self_depart_topic(&self.zenoh_prefix))
+            .res()
             .await
             .map_err(|e| eyre!(e))
             .context("failed to declare self depart subscriber")?;
-        let mut self_depart_stream = self_depart_subscriber.receiver().fuse();
+        let mut self_depart_stream = self_depart_subscriber.receiver.into_stream();
 
         // responsible for handling requests
-        let mut request_subscriber = zenoh
-            .subscribe(&self.wt.request_topic(&self.zenoh_prefix))
+        let request_subscriber = zenoh
+            .declare_subscriber(&self.wt.request_topic(&self.zenoh_prefix))
+            .res()
             .await
             .map_err(|e| eyre!(e))
             .context("failed to declare request subscriber")?;
-        let mut request_stream = request_subscriber.receiver().fuse();
+        let mut request_stream = request_subscriber.receiver.into_stream();
 
         // responsible for processing gossip
-        let mut gossip_subscriber = zenoh
-            .subscribe(&self.wt.gossip_topic(&self.zenoh_prefix))
+        let gossip_subscriber = zenoh
+            .declare_subscriber(&self.wt.gossip_topic(&self.zenoh_prefix))
+            .res()
             .await
             .map_err(|e| eyre!(e))
             .context("failed to declare gossip subscriber")?;
-        let mut gossip_stream = gossip_subscriber.receiver().fuse();
+        let mut gossip_stream = gossip_subscriber.receiver.into_stream();
 
         // responsible for listening for key replication factor response
-        let mut replication_response_subscriber = zenoh
-            .subscribe(&self.wt.replication_response_topic(&self.zenoh_prefix))
+        let replication_response_subscriber = zenoh
+            .declare_subscriber(&self.wt.replication_response_topic(&self.zenoh_prefix))
+            .res()
             .await
             .map_err(|e| eyre!(e))
             .context("failed to declare replication response subscriber")?;
-        let mut replication_response_stream = replication_response_subscriber.receiver().fuse();
+        let mut replication_response_stream =
+            replication_response_subscriber.receiver.into_stream();
 
         // responsible for listening for key replication factor change
-        let mut replication_change_subscriber = zenoh
-            .subscribe(&self.wt.replication_change_topic(&self.zenoh_prefix))
+        let replication_change_subscriber = zenoh
+            .declare_subscriber(&self.wt.replication_change_topic(&self.zenoh_prefix))
+            .res()
             .await
             .map_err(|e| eyre!(e))
             .context("failed to declare replication change subscriber")?;
-        let mut replication_change_stream = replication_change_subscriber.receiver().fuse();
+        let mut replication_change_stream = replication_change_subscriber.receiver.into_stream();
 
         // responsible for listening for cached keys response messages.
-        let mut cache_ip_subscriber = zenoh
-            .subscribe(&self.wt.cache_ip_response_topic(&self.zenoh_prefix))
+        let cache_ip_subscriber = zenoh
+            .declare_subscriber(&self.wt.cache_ip_response_topic(&self.zenoh_prefix))
+            .res()
             .await
             .map_err(|e| eyre!(e))
             .context("failed to declare cache ip subscriber")?;
-        let mut cache_ip_stream = cache_ip_subscriber.receiver().fuse();
+        let mut cache_ip_stream = cache_ip_subscriber.receiver.into_stream();
 
         // responsible for listening for function node IP lookup response messages.
-        let mut management_node_response_subscriber = zenoh
-            .subscribe(&self.wt.management_node_response_topic(&self.zenoh_prefix))
+        let management_node_response_subscriber = zenoh
+            .declare_subscriber(&self.wt.management_node_response_topic(&self.zenoh_prefix))
+            .res()
             .await
             .map_err(|e| eyre!(e))
             .context("failed to declare management node response subscriber")?;
         let mut management_node_response_stream =
-            management_node_response_subscriber.receiver().fuse();
+            management_node_response_subscriber.receiver.into_stream();
 
         match self.config_data.self_tier {
             Tier::Memory => {
@@ -605,14 +619,15 @@ impl KvsNode {
             tasks.push(async move {
                 let reply = loop {
                     let topic = routing_thread.tcp_addr_topic(&s.zenoh_prefix);
-                    let mut receiver = s
+                    let receiver = s
                         .zenoh
                         .get(&topic)
+                        .res()
                         .await
                         .map_err(|e| eyre!(e))
                         .context("failed to query tcp address of routing thread")?;
-                    match receiver.next().await {
-                        Some(reply) => break reply.sample.value,
+                    match receiver.recv_async().await.ok() {
+                        Some(reply) => break reply.sample.map_err(|err| eyre::eyre!(err))?.value,
                         None => {
                             log::info!("failed to receive tcp address reply");
                             futures_timer::Delay::new(Duration::from_secs(1)).await;

--- a/src/nodes/kvs/report.rs
+++ b/src/nodes/kvs/report.rs
@@ -17,6 +17,7 @@ use std::{
     collections::{BTreeSet, HashMap},
     time::{Duration, Instant},
 };
+use zenoh::prelude::r#async::AsyncResolve;
 
 // define server's key monitoring threshold
 const K_KEY_MONITORING_THRESHOLD: Duration = Duration::from_secs(60);
@@ -125,6 +126,7 @@ impl ReportData {
                         response_topic: wt.management_node_response_topic(zenoh_prefix).to_string(),
                     })?,
                 )
+                .res()
                 .await
                 .map_err(|e| eyre::eyre!(e))?;
         }

--- a/src/nodes/kvs/report.rs
+++ b/src/nodes/kvs/report.rs
@@ -98,6 +98,7 @@ impl ReportData {
     }
 
     /// Starts the next reporting epoch and returns the report messages that should be sent out.
+    #[allow(clippy::too_many_arguments)]
     pub async fn next_epoch(
         &mut self,
         duration: Duration,

--- a/src/nodes/monitoring/handlers/depart_done.rs
+++ b/src/nodes/monitoring/handlers/depart_done.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use eyre::{anyhow, bail, Context};
 use std::time::Instant;
+use zenoh::prelude::r#async::AsyncResolve;
 
 impl<'a> MonitoringNode<'a> {
     pub(in crate::nodes::monitoring) async fn depart_done_handler(
@@ -51,6 +52,7 @@ impl<'a> MonitoringNode<'a> {
                             departed_node_id: departed.node_id,
                         })?,
                     )
+                    .res()
                     .await
                     .map_err(|e| eyre::eyre!(e))?;
             }

--- a/src/nodes/monitoring/mod.rs
+++ b/src/nodes/monitoring/mod.rs
@@ -373,7 +373,7 @@ impl<'a> MonitoringNode<'a> {
                     // NB: response_address might not be necessary here
                     // (or in other places where req_id is constructed either).
                     request_id: Some(format!("{}:{}", response_addr, self.request_id)),
-                    response_address: Some(response_addr.to_string()),
+                    response_address: Some(response_addr),
                     address_cache_size: Default::default(),
                 });
                 self.request_id += 1;
@@ -413,7 +413,7 @@ impl<'a> MonitoringNode<'a> {
                     // NB: response_address might not be necessary here
                     // (or in other places where req_id is constructed either).
                     request_id: Some(format!("{}:{}", response_addr, self.request_id)),
-                    response_address: Some(response_addr.to_string()),
+                    response_address: Some(response_addr),
                     address_cache_size: Default::default(),
                 });
                 self.request_id += 1;
@@ -479,7 +479,7 @@ impl<'a> MonitoringNode<'a> {
             .insert(node_id, self.config_data.tier_metadata[&tier].thread_number);
         // the depart done message should be sent to our depart done topic
         let self_depart = SelfDepart {
-            response_topic: self.mt.depart_done_topic(&self.zenoh_prefix).to_string(),
+            response_topic: self.mt.depart_done_topic(&self.zenoh_prefix),
         };
 
         self.zenoh

--- a/src/nodes/monitoring/stats.rs
+++ b/src/nodes/monitoring/stats.rs
@@ -17,6 +17,7 @@ use std::{
     collections::{HashMap, HashSet},
     convert::TryFrom,
 };
+use zenoh::prelude::r#async::AsyncResolve;
 
 impl<'a> MonitoringNode<'a> {
     /// Queries statistics from all KVS threads.
@@ -79,6 +80,7 @@ impl<'a> MonitoringNode<'a> {
                 serde_json::to_string(&request).context("failed to serialize KeyRequest")?;
             self.zenoh
                 .put(&address, serialized_req)
+                .res()
                 .await
                 .map_err(|e| eyre::eyre!(e))?;
 

--- a/src/nodes/routing/handlers/address.rs
+++ b/src/nodes/routing/handlers/address.rs
@@ -147,8 +147,8 @@ mod tests {
     fn address() {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
-        let mut subscriber = zenoh
-            .declare_subscriber(format!("{}/**", zenoh_prefix))
+        let subscriber = zenoh
+            .declare_subscriber(format!("{zenoh_prefix}/**"))
             .res()
             .unwrap();
 

--- a/src/nodes/routing/handlers/address.rs
+++ b/src/nodes/routing/handlers/address.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use crate::{
     messages::{AddressRequest, AddressResponse, KeyAddress, TcpMessage},
     nodes::{routing::RoutingNode, send_tcp_message},
@@ -70,10 +68,7 @@ impl RoutingNode {
                             self.pending_requests.entry(key.clone()).or_default().push(
                                 crate::nodes::routing::PendingRequest {
                                     request_id: addr_request.request_id,
-                                    reply_path: addr_request
-                                        .response_address
-                                        .try_into()
-                                        .context("invalid response address")?,
+                                    reply_path: addr_request.response_address,
                                     reply_stream,
                                 },
                             );

--- a/src/nodes/routing/handlers/membership.rs
+++ b/src/nodes/routing/handlers/membership.rs
@@ -6,6 +6,7 @@ use crate::{
     ALL_TIERS,
 };
 use eyre::Context;
+use zenoh::prelude::r#async::AsyncResolve;
 
 impl RoutingNode {
     /// Handles incoming [`Notify`][crate::messages::Notify] messages.
@@ -48,6 +49,7 @@ impl RoutingNode {
                                             .node_join_topic(&self.zenoh_prefix),
                                         msg.as_str(),
                                     )
+                                    .res()
                                     .await
                                     .map_err(|e| eyre::eyre!(e))
                                     .context("failed to send ip of newly joined node")?;
@@ -65,6 +67,7 @@ impl RoutingNode {
                                     .notify_topic(&self.zenoh_prefix),
                                 serialized.as_str(),
                             )
+                            .res()
                             .await
                             .map_err(|e| eyre::eyre!(e))
                             .context("failed to forward join message to worker threads")?;
@@ -109,6 +112,7 @@ impl RoutingNode {
                                     .notify_topic(&self.zenoh_prefix),
                                 serialized.as_str(),
                             )
+                            .res()
                             .await
                             .map_err(|e| eyre::eyre!(e))
                             .context("failed to forward depart message to worker threads")?;
@@ -134,7 +138,8 @@ impl RoutingNode {
 
 #[cfg(test)]
 mod tests {
-    use zenoh::prelude::{Receiver, ZFuture};
+
+    use zenoh::prelude::sync::SyncResolve;
 
     use crate::{
         messages::{self, Tier},
@@ -148,8 +153,8 @@ mod tests {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
         let mut subscriber = zenoh
-            .subscribe(format!("{}/**", zenoh_prefix))
-            .wait()
+            .declare_subscriber(format!("{}/**", zenoh_prefix))
+            .res()
             .unwrap();
 
         let mut router = router_test_instance(zenoh.clone(), zenoh_prefix);
@@ -170,7 +175,7 @@ mod tests {
 
         let message: messages::Join = {
             let sample = subscriber
-                .receiver()
+                .receiver
                 .recv_timeout(Duration::from_secs(10))
                 .unwrap();
             serde_json::from_str(&sample.value.as_string().unwrap()).unwrap()

--- a/src/nodes/routing/handlers/membership.rs
+++ b/src/nodes/routing/handlers/membership.rs
@@ -89,7 +89,7 @@ impl RoutingNode {
                 log::info!("Received depart from server {}.", departed_node_id,);
                 self.global_hash_rings
                     .entry(*tier)
-                    .and_modify(|e| e.remove_node(&departed_node_id));
+                    .and_modify(|e| e.remove_node(departed_node_id));
 
                 for i in 0.. {
                     let departed_thread = KvsThread {
@@ -152,8 +152,8 @@ mod tests {
     fn membership() {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
-        let mut subscriber = zenoh
-            .declare_subscriber(format!("{}/**", zenoh_prefix))
+        let subscriber = zenoh
+            .declare_subscriber(format!("{zenoh_prefix}/**"))
             .res()
             .unwrap();
 

--- a/src/nodes/routing/handlers/replication_change.rs
+++ b/src/nodes/routing/handlers/replication_change.rs
@@ -73,8 +73,8 @@ mod tests {
     fn replication_change() {
         let zenoh = zenoh_test_instance();
         let zenoh_prefix = uuid::Uuid::new_v4().to_string();
-        let mut subscriber = zenoh
-            .declare_subscriber(format!("{}/**", zenoh_prefix))
+        let subscriber = zenoh
+            .declare_subscriber(format!("{zenoh_prefix}/**"))
             .res()
             .unwrap();
 
@@ -83,7 +83,7 @@ mod tests {
             .map(|&k| ClientKey::from(k))
             .collect();
 
-        let mut router = router_test_instance(zenoh.clone(), zenoh_prefix.clone());
+        let mut router = router_test_instance(zenoh.clone(), zenoh_prefix);
         router.config_data = Arc::new(ConfigData {
             routing_thread_count: 3,
             ..(*router.config_data).clone()

--- a/src/nodes/routing/handlers/replication_response.rs
+++ b/src/nodes/routing/handlers/replication_response.rs
@@ -192,7 +192,7 @@ mod tests {
 
         let key: ClientKey = "key".into();
 
-        let mut router = router_test_instance(zenoh.clone(), zenoh_prefix);
+        let mut router = router_test_instance(zenoh, zenoh_prefix);
         let entry = router.key_replication_map.entry(key.clone()).or_default();
 
         entry.global_replication.insert(Tier::Memory, 1);

--- a/src/nodes/routing/handlers/replication_response.rs
+++ b/src/nodes/routing/handlers/replication_response.rs
@@ -9,6 +9,7 @@ use crate::{
     AnnaError, ClientKey, Key, ALL_TIERS,
 };
 use eyre::{anyhow, bail, Context};
+use zenoh::prelude::r#async::AsyncResolve;
 
 impl RoutingNode {
     /// Handles incoming replication response messages.
@@ -143,6 +144,7 @@ impl RoutingNode {
                         .context("failed to serialize KeyAddressResponse")?;
                     self.zenoh
                         .put(&pending_key_req.reply_path.clone(), serialized)
+                        .res()
                         .await
                         .map_err(|e| eyre::eyre!(e))
                         .context("failed to send key address response")?;

--- a/src/nodes/routing/mod.rs
+++ b/src/nodes/routing/mod.rs
@@ -251,7 +251,7 @@ impl RoutingNode {
         // subscribe to zenoh topics
         let zenoh = self.zenoh.clone();
 
-        let mut tcp_addr_queryable = zenoh
+        let tcp_addr_queryable = zenoh
             .declare_queryable(&self.rt.tcp_addr_topic(&self.zenoh_prefix))
             .res()
             .await
@@ -261,7 +261,7 @@ impl RoutingNode {
 
         // responsible for sending existing server addresses to a new node (relevant
         // to seed node)
-        let mut address_queryable = zenoh
+        let address_queryable = zenoh
             .declare_queryable(&RoutingThread::seed_topic(&self.zenoh_prefix))
             .res()
             .await
@@ -270,7 +270,7 @@ impl RoutingNode {
         let mut address_request_stream = address_queryable.receiver.into_stream();
 
         // responsible for both node join and departure
-        let mut notify_subscriber = zenoh
+        let notify_subscriber = zenoh
             .declare_subscriber(&self.rt.notify_topic(&self.zenoh_prefix))
             .res()
             .await
@@ -279,7 +279,7 @@ impl RoutingNode {
         let mut notify_stream = notify_subscriber.receiver.into_stream();
 
         // responsible for listening for key replication factor response
-        let mut replication_response_subscriber = zenoh
+        let replication_response_subscriber = zenoh
             .declare_subscriber(&self.rt.replication_response_topic(&self.zenoh_prefix))
             .res()
             .await
@@ -290,7 +290,7 @@ impl RoutingNode {
 
         // responsible for handling key replication factor change requests from server
         // nodes
-        let mut replication_change_subscriber = zenoh
+        let replication_change_subscriber = zenoh
             .declare_subscriber(&self.rt.replication_change_topic(&self.zenoh_prefix))
             .res()
             .await
@@ -299,7 +299,7 @@ impl RoutingNode {
         let mut replication_change_stream = replication_change_subscriber.receiver.into_stream();
 
         // responsible for handling key address request from users
-        let mut key_address_subscriber = zenoh
+        let key_address_subscriber = zenoh
             .declare_subscriber(&self.rt.address_request_topic(&self.zenoh_prefix))
             .res()
             .await
@@ -307,7 +307,7 @@ impl RoutingNode {
             .context("failed to declare key address subscriber")?;
         let mut key_address_stream = key_address_subscriber.receiver.into_stream();
 
-        let mut routing_ad_subscriber = zenoh
+        let routing_ad_subscriber = zenoh
             .declare_subscriber(&RoutingThread::advertisement_topic(&self.zenoh_prefix))
             .res()
             .await
@@ -351,7 +351,7 @@ impl RoutingNode {
         let zenoh = self.zenoh.clone();
         let zenoh_prefix = self.zenoh_prefix.clone();
         std::thread::spawn(move || {
-            let mut ping_subscriber = zenoh::prelude::sync::SyncResolve::res_sync(
+            let ping_subscriber = zenoh::prelude::sync::SyncResolve::res_sync(
                 zenoh.declare_subscriber(&rt.ping_topic(&zenoh_prefix)),
             )
             .map_err(|e| eyre::eyre!(e))
@@ -370,7 +370,7 @@ impl RoutingNode {
         let zenoh = self.zenoh.clone();
         let zenoh_prefix = self.zenoh_prefix.clone();
         std::thread::spawn(move || {
-            let mut ping_subscriber = zenoh::prelude::sync::SyncResolve::res_sync(
+            let ping_subscriber = zenoh::prelude::sync::SyncResolve::res_sync(
                 zenoh.declare_queryable(&rt.ping_topic(&zenoh_prefix)),
             )
             .map_err(|e| eyre::eyre!(e))

--- a/src/nodes/routing/mod.rs
+++ b/src/nodes/routing/mod.rs
@@ -381,7 +381,8 @@ impl RoutingNode {
                     request
                         .reply(Ok(Sample::try_from("pong", "pong").unwrap()))
                         .res()
-                        .await;
+                        .await
+                        .map_err(|err| eyre::eyre!(err))?;
                 }
                 Result::<_, eyre::Error>::Ok(())
             })
@@ -437,12 +438,12 @@ impl RoutingNode {
                 }
 
                 query = tcp_addr_request_stream.select_next_some() => {
-                    query.reply(Ok(Sample::new(query.key_expr().to_owned(), tcp_addr_serialized.as_str()))).res().await;
+                    query.reply(Ok(Sample::new(query.key_expr().to_owned(), tcp_addr_serialized.as_str()))).res().await.map_err(|err| eyre::eyre!(err))?;
                 }
                 query = address_request_stream.select_next_some() => {
                     log::info!("handling address request for {}", query.selector());
                     let serialized_reply = self.seed_handler();
-                    query.reply(Ok(Sample::new(query.key_expr().to_owned(), serialized_reply))).res().await;
+                    query.reply(Ok(Sample::new(query.key_expr().to_owned(), serialized_reply))).res().await.map_err(|err| eyre::eyre!(err))?;
                 }
                 sample = notify_stream.select_next_some() => {
                     let parsed = serde_json::from_str(&sample.value.as_string()?)

--- a/src/topics.rs
+++ b/src/topics.rs
@@ -2,8 +2,6 @@
 //!
 //! Allows to address specific threads of specific nodes.
 
-use std::convert::TryInto;
-
 // The topic on which clients send key address requests to routing nodes.
 const KEY_ADDRESS_TOPIC: &str = "key_address";
 
@@ -103,8 +101,6 @@ impl KvsThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, NODE_JOIN_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 
     /// After nodes departed the cluster, a [`Departed`][crate::messages::Departed]
@@ -114,8 +110,6 @@ impl KvsThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, NODE_DEPART_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 
     /// Topic for notifying a node thread that it itself should leave.
@@ -127,8 +121,6 @@ impl KvsThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, SELF_DEPART_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 
     /// The topic on which [`Request`][crate::messages::Request] messages are sent.
@@ -137,8 +129,6 @@ impl KvsThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, KEY_REQUEST_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 
     /// Topic on which gossip messages are sent.
@@ -149,8 +139,6 @@ impl KvsThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, GOSSIP_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 
     /// Used to notify KVS threads about replication factor changes.
@@ -163,8 +151,6 @@ impl KvsThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, SERVER_REPLICATION_CHANGE_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 
     /// The topic on which responses to replication requests are sent.
@@ -175,8 +161,6 @@ impl KvsThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, SERVER_REPLICATION_RESPONSE_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 
     /// Used for cached keys response messages, not fully implemented yet.
@@ -185,8 +169,6 @@ impl KvsThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, CACHE_IP_RESPONSE_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 
     /// Used for response messages from the management node, not fully implemented yet.
@@ -195,8 +177,6 @@ impl KvsThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, MANAGEMENT_NODE_RESPONSE_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 }
 
@@ -225,8 +205,6 @@ impl ClientThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, USER_RESPONSE_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 
     /// The topic on which [`AddressResponse`][crate::messages::AddressResponse] messages should
@@ -239,8 +217,6 @@ impl ClientThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, USER_KEY_ADDRESS_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 }
 
@@ -263,14 +239,12 @@ impl RoutingThread {
     /// message. Unlike most other messages in this crate, the `"join"` is sent as
     /// zenoh [`get`][zenoh::Workspace::get] requests with an immediate reply.
     pub fn seed_topic(prefix: &str) -> String {
-        format!("{prefix}/{SEED_TOPIC}").try_into().unwrap()
+        format!("{prefix}/{SEED_TOPIC}")
     }
 
     /// Each routing node broadcasts its ID on this topic.
     pub fn advertisement_topic(prefix: &str) -> String {
         format!("{prefix}/{ADVERTISEMENT_TOPIC}")
-            .try_into()
-            .unwrap()
     }
 
     /// Addresses the given thread on the given routing node.
@@ -281,8 +255,6 @@ impl RoutingThread {
     /// Topic used for creating a point-to-point connection to this routing thread.
     pub fn p2p_topic(&self, prefix: &str) -> String {
         format!("{}/{}/{}", prefix, self.node_id, self.thread_id)
-            .try_into()
-            .unwrap()
     }
 
     /// Nodes can request the public IP address of the routing node under this topic.
@@ -291,8 +263,6 @@ impl RoutingThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, TCP_PORT_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 
     /// Used to notify routing threads of node joins and departures.
@@ -303,8 +273,6 @@ impl RoutingThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, ROUTING_NOTIFY_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 
     /// Client nodes request the KVS node responsible for a given key on this topic.
@@ -315,8 +283,6 @@ impl RoutingThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, KEY_ADDRESS_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 
     /// Topic for notifying routing nodes of replication changes.
@@ -328,8 +294,6 @@ impl RoutingThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, ROUTING_REPLICATION_CHANGE_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 
     /// The topic on which responses to replication requests are sent.
@@ -340,15 +304,11 @@ impl RoutingThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, ROUTING_REPLICATION_RESPONSE_TOPIC, self.thread_id
         )
-        .try_into()
-        .unwrap()
     }
 
     /// The routing node responds to "ping" messages sent on this topic.
     pub fn ping_topic(&self, prefix: &str) -> String {
         format!("{}/{}/{}/{}", prefix, self.node_id, "ping", self.thread_id)
-            .try_into()
-            .unwrap()
     }
 }
 
@@ -369,8 +329,6 @@ impl MonitoringThread {
     /// Sent messages are of type [`Notify`][crate::messages::Notify].
     pub fn notify_topic(prefix: &str) -> String {
         format!("{prefix}/{MONITORING_NOTIFY_TOPIC}")
-            .try_into()
-            .unwrap()
     }
 
     /// Monitoring nodes are informed about finished departures on this topic.
@@ -378,8 +336,6 @@ impl MonitoringThread {
     /// Sent messages are of type [`Departed`][crate::messages::Departed].
     pub fn depart_done_topic(&self, prefix: &str) -> String {
         format!("{}/{}/{}", prefix, self.node_id, DEPART_DONE_TOPIC)
-            .try_into()
-            .unwrap()
     }
 
     /// Monitoring nodes expect responses on this topic.
@@ -387,16 +343,12 @@ impl MonitoringThread {
     /// Sent messages are of type [`Response`][crate::messages::Response].
     pub fn response_topic(&self, prefix: &str) -> String {
         format!("{}/{}/{}", prefix, self.node_id, MONITORING_RESPONSE_TOPIC)
-            .try_into()
-            .unwrap()
     }
 
     /// Benchmarking nodes send [`UserFeedback`][crate::messages::user_feedback::UserFeedback]
     /// messages to the monitoring nodes on this topic.
     pub fn feedback_report_topic(prefix: &str) -> String {
         format!("{prefix}/{FEEDBACK_REPORT_TOPIC}")
-            .try_into()
-            .unwrap()
     }
 }
 
@@ -418,8 +370,6 @@ impl CacheThread {
             "{}/{}/{}/{}",
             prefix, self.node_id, CACHE_UPDATE_TOPIC, self.tid
         )
-        .try_into()
-        .unwrap()
     }
 }
 
@@ -447,8 +397,6 @@ impl ManagementThread {
     /// [`AddNodes`][crate::messages::management::AddNodes].
     pub fn add_nodes_topic(&self, prefix: &str) -> String {
         format!("{}/{}/{}", prefix, self.node_id, Self::ADD_NODES_TOPIC)
-            .try_into()
-            .unwrap()
     }
 
     /// Tells the management node to shut down a node.
@@ -457,8 +405,6 @@ impl ManagementThread {
     /// [`RemoveNode`][crate::messages::management::RemoveNode].
     pub fn remove_node_topic(&self, prefix: &str) -> String {
         format!("{}/{}/{}", prefix, self.node_id, Self::REMOVE_NODE_TOPIC)
-            .try_into()
-            .unwrap()
     }
 
     /// Topic on which
@@ -471,16 +417,10 @@ impl ManagementThread {
             self.node_id,
             Self::QUERY_FUNC_NODES_TOPIC
         )
-        .try_into()
-        .unwrap()
     }
 }
 
 /// Topic on which commands to benchmark nodes are sent.
 pub fn benchmark_topic(thread_id: u32, zenoh_prefix: &str) -> String {
-    format!(
-        "{zenoh_prefix}/benchmark/{BENCHMARK_COMMAND_TOPIC}/{thread_id}",
-    )
-    .try_into()
-    .unwrap()
+    format!("{zenoh_prefix}/benchmark/{BENCHMARK_COMMAND_TOPIC}/{thread_id}",)
 }

--- a/src/topics.rs
+++ b/src/topics.rs
@@ -263,12 +263,12 @@ impl RoutingThread {
     /// message. Unlike most other messages in this crate, the `"join"` is sent as
     /// zenoh [`get`][zenoh::Workspace::get] requests with an immediate reply.
     pub fn seed_topic(prefix: &str) -> String {
-        format!("{}/{}", prefix, SEED_TOPIC).try_into().unwrap()
+        format!("{prefix}/{SEED_TOPIC}").try_into().unwrap()
     }
 
     /// Each routing node broadcasts its ID on this topic.
     pub fn advertisement_topic(prefix: &str) -> String {
-        format!("{}/{}", prefix, ADVERTISEMENT_TOPIC)
+        format!("{prefix}/{ADVERTISEMENT_TOPIC}")
             .try_into()
             .unwrap()
     }
@@ -368,7 +368,7 @@ impl MonitoringThread {
     ///
     /// Sent messages are of type [`Notify`][crate::messages::Notify].
     pub fn notify_topic(prefix: &str) -> String {
-        format!("{}/{}", prefix, MONITORING_NOTIFY_TOPIC)
+        format!("{prefix}/{MONITORING_NOTIFY_TOPIC}")
             .try_into()
             .unwrap()
     }
@@ -394,7 +394,7 @@ impl MonitoringThread {
     /// Benchmarking nodes send [`UserFeedback`][crate::messages::user_feedback::UserFeedback]
     /// messages to the monitoring nodes on this topic.
     pub fn feedback_report_topic(prefix: &str) -> String {
-        format!("{}/{}", prefix, FEEDBACK_REPORT_TOPIC)
+        format!("{prefix}/{FEEDBACK_REPORT_TOPIC}")
             .try_into()
             .unwrap()
     }
@@ -479,8 +479,7 @@ impl ManagementThread {
 /// Topic on which commands to benchmark nodes are sent.
 pub fn benchmark_topic(thread_id: u32, zenoh_prefix: &str) -> String {
     format!(
-        "{}/benchmark/{}/{}",
-        zenoh_prefix, BENCHMARK_COMMAND_TOPIC, thread_id,
+        "{zenoh_prefix}/benchmark/{BENCHMARK_COMMAND_TOPIC}/{thread_id}",
     )
     .try_into()
     .unwrap()

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -84,8 +84,8 @@ fn get_set() {
         &mut stdout,
         &mut stderr,
         true,
-        zenoh.clone(),
-        zenoh_prefix.clone(),
+        zenoh,
+        zenoh_prefix,
     )
     .unwrap();
     assert_eq!(String::from_utf8(stderr.into_inner()).unwrap(), "");


### PR DESCRIPTION
This PR updates the `zenoh` dependency to the latest crates.io version. We were using a pinned commit before.

The new zenoh release should improve performance, which hopefully also makes our project faster. Another advantage of this change is that it removes the last git dependency, so we should be able to publish our crate to crates.io afterwards.